### PR TITLE
Regenerate datamodel on Apple Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ set(FCCEDM_PATCH_VERSION 0)
 set(FCCEDM_VERSION
   ${FCCEDM_MAJOR_VERSION}.${FCCEDM_MINOR_VERSION}.${FCCEDM_PATCH_VERSION})
 
+if(APPLE)
+  execute_process(COMMAND python $ENV{PODIO}/python/podio_class_generator.py edm.yaml datamodel datamodel
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+endif(APPLE)
+
 #--- Declare options -----------------------------------------------------------
 option(fccedm_documentation "Whether or not to create doxygen doc target.")
 


### PR DESCRIPTION
Hi,

I noticed that while the package is compiling fine on Linux (Fedora) it fails on Mac OS X El Capitan 10.11.6 with a rather lengthy [output](https://github.com/cbernet/fcc-edm/files/596078/output.txt)  - an excerpt is following:

```text
In file included from /tmp/fcc-edm/utilities/DummyGenerator.cc:3:
/Users/fthiele/fcc/podio/install/include/podio/EventStore.h:93:17: error: allocating an object of abstract class
      type 'fcc::ParticleCollection'
  T* coll = new T();
                ^
/tmp/fcc-edm/utilities/DummyGenerator.cc:32:21: note: in instantiation of function template specialization
      'podio::EventStore::create<fcc::ParticleCollection>' requested here
  m_particles(store.create<fcc::ParticleCollection>("GenParticle")),
                    ^
/Users/fthiele/fcc/podio/install/include/podio/CollectionBase.h:49:18: note: unimplemented pure virtual method
      'isValid' in 'ParticleCollection'
    virtual bool isValid() const = 0;
                 ^
```

However when inserting into [CMakeLists.txt](https://github.com/cbernet/fcc-edm/blob/master/CMakeLists.txt) the following:
```cmake
execute_process(COMMAND python $ENV{PODIO}/python/podio_class_generator.py edm.yaml datamodel datamodel
                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
```
it compiles fine. Now I haven't looked into this in detail but it seems that the datamodel classes in [datamodel](https://github.com/cbernet/fcc-edm/tree/master/datamodel/datamodel) need to be regenerated by the podio class generator on mac specifically.

In the pull request to this issue the `if(APPLE)` is only included as currently the repository compiles fine on my linux machine. Version is tested with both Mac OS X (El Capitan) as well as Linux (Fedora 24).

Best,

Fabian

